### PR TITLE
Add AdvSendPrefix flag and fix a minor bug

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -59,6 +59,7 @@
 #define DFLT_AdvOnLinkFlag 1
 #define DFLT_AdvPreferredLifetime 14400 /* seconds */
 #define DFLT_AdvAutonomousFlag 1
+#define DFLT_AdvSendPrefix 1
 #define DFLT_DeprecatePrefixFlag 0
 #define DFLT_DecrementLifetimesFlag 0
 

--- a/radvd.c
+++ b/radvd.c
@@ -18,6 +18,8 @@
 #include "includes.h"
 #include "pathnames.h"
 
+#define SERVER_PATH "/tmp/radvd.sock"
+
 #ifdef HAVE_NETLINK
 #include "netlink.h"
 #endif
@@ -27,8 +29,6 @@
 #include <sys/file.h>
 
 #ifdef HAVE_GETOPT_LONG
-
-#define SERVER_PATH "/tmp/radvd.sock"
 
 /* clang-format off */
 static char usage_str[] = {
@@ -538,9 +538,9 @@ static struct Interface *main_loop(int sock, struct Interface *ifaces, char cons
 			ts.tv_nsec = (timeout - 1000 * ts.tv_sec) * 1000000;
 			tsp = &ts;
 
-			if(next_iface_to_expire->props.name[0] != '\0') {
+			if (next_iface_to_expire->props.name[0] != '\0') {
 				dlog(LOG_DEBUG, 1, "polling for %g second(s), next iface is %s", timeout / 1000.0,
-			    next_iface_to_expire->props.name);
+				     next_iface_to_expire->props.name);
 			}
 			dlog(LOG_DEBUG, 1, "polling for %g second(s), next cdb_iface is %s", timeout / 1000.0,
 			     next_iface_to_expire->props.cdb_name);
@@ -611,8 +611,8 @@ static struct Interface *main_loop(int sock, struct Interface *ifaces, char cons
 		if (sighup_received) {
 			dlog(LOG_INFO, 3, "sig hup received");
 			// ifaces = reload_config(sock, ifaces, conf_path);
-			if(ifaces != NULL && sock < 0)
-			setup_iface(sock, ifaces);
+			if (ifaces != NULL && sock < 0)
+				setup_iface(sock, ifaces);
 			sighup_received = 0;
 		}
 
@@ -947,7 +947,7 @@ static struct Interface *process_command(int sock, struct Interface *ifaces)
 {
 	char buffer[4096];
 	ssize_t rc = recv(sock, buffer, 4096, MSG_WAITALL);
-	if(rc < 0) {
+	if (rc < 0) {
 		flog(LOG_ERR, "Error on recv %s", strerror(errno));
 		return ifaces;
 	}
@@ -963,7 +963,6 @@ static struct Interface *process_command(int sock, struct Interface *ifaces)
 	char *iface_cdb_name;
 	char *addr_str;
 
-
 	if (!(cjson_ra_config = cJSON_Parse(buffer))) {
 		dlog(LOG_DEBUG, 1, "cJSON Parsing error");
 		return ifaces;
@@ -978,7 +977,7 @@ static struct Interface *process_command(int sock, struct Interface *ifaces)
 		cJSON_Delete(cjson_ra_config);
 		return ifaces;
 	}
-	if(!(iface_cdb_name = cJSON_GetStringValue(cjson_cdb_name))) {
+	if (!(iface_cdb_name = cJSON_GetStringValue(cjson_cdb_name))) {
 		dlog(LOG_DEBUG, 1, "cJSON interface cdb_name is not a string");
 		cJSON_Delete(cjson_ra_config);
 		return ifaces;
@@ -986,8 +985,8 @@ static struct Interface *process_command(int sock, struct Interface *ifaces)
 
 	cjson_destructive_iface = cJSON_GetObjectItemCaseSensitive(cjson_interface, "destructive");
 
-	if(cjson_destructive_iface){
-		if(cJSON_IsTrue(cjson_destructive_iface)) {
+	if (cjson_destructive_iface) {
+		if (cJSON_IsTrue(cjson_destructive_iface)) {
 			dlog(LOG_DEBUG, 1, "cJSON destroying interface");
 			ifaces = delete_iface_by_cdb_name(ifaces, iface_cdb_name);
 			return ifaces;
@@ -1015,13 +1014,14 @@ static struct Interface *process_command(int sock, struct Interface *ifaces)
 
 	iface = update_iface(iface, cjson_interface);
 
-	if(!(cjson_prefixes = cJSON_GetObjectItemCaseSensitive(cjson_interface, "prefixes"))) {
+	if (!(cjson_prefixes = cJSON_GetObjectItemCaseSensitive(cjson_interface, "prefixes"))) {
 		dlog(LOG_DEBUG, 1, "cJSON prefixes error");
 		cJSON_Delete(cjson_ra_config);
 		return ifaces;
 	}
 
-	cJSON_ArrayForEach(cjson_prefix, cjson_prefixes) {
+	cJSON_ArrayForEach(cjson_prefix, cjson_prefixes)
+	{
 		cjson_destructive_prefix = cJSON_GetObjectItemCaseSensitive(cjson_prefix, "destructive");
 		struct in6_addr addr6;
 
@@ -1037,8 +1037,8 @@ static struct Interface *process_command(int sock, struct Interface *ifaces)
 			dlog(LOG_DEBUG, 1, "Invalid IPV6 prefix");
 			continue;
 		}
-		if(cjson_destructive_prefix) {
-			if(cJSON_IsTrue(cjson_destructive_prefix)) {
+		if (cjson_destructive_prefix) {
+			if (cJSON_IsTrue(cjson_destructive_prefix)) {
 				dlog(LOG_DEBUG, 1, "cJSON destroying prefix");
 				iface->AdvPrefixList = delete_iface_prefix_by_addr(iface->AdvPrefixList, addr_str);
 				continue;

--- a/radvd.h
+++ b/radvd.h
@@ -73,7 +73,7 @@ struct Interface {
 	} state_info;
 
 	struct properties {
-		char name[IFNAMSIZ]; /* interface name */
+		char name[IFNAMSIZ];	/* interface name */
 		char cdb_name[IFCDBNAMSIZ]; /* CDB interface name */
 		unsigned int if_index;
 		struct in6_addr if_addr;   /* the first link local addr */
@@ -146,6 +146,7 @@ struct AdvPrefix {
 
 	int AdvOnLinkFlag;
 	int AdvAutonomousFlag;
+	int AdvSendPrefix;
 	uint32_t AdvValidLifetime;
 	uint32_t AdvPreferredLifetime;
 	int DeprecatePrefixFlag;
@@ -309,8 +310,8 @@ struct Interface *update_iface(struct Interface *iface, cJSON *cjson_iface);
 struct AdvPrefix *create_prefix(const char *addr6_str);
 struct AdvPrefix *find_prefix_by_addr(struct AdvPrefix *prefix_list, const struct in6_addr addr6);
 struct AdvPrefix *update_iface_prefix(struct AdvPrefix *prefix, cJSON *cjson_prefix);
-struct Interface * delete_iface_by_cdb_name(struct Interface *ifaces, const char *if_name);
-struct AdvPrefix * delete_iface_prefix_by_addr(struct AdvPrefix *prefix_list, const char *addr6_str);
+struct Interface *delete_iface_by_cdb_name(struct Interface *ifaces, const char *if_name);
+struct AdvPrefix *delete_iface_prefix_by_addr(struct AdvPrefix *prefix_list, const char *addr6_str);
 void dnssl_init_defaults(struct AdvDNSSL *, struct Interface *);
 void for_each_iface(struct Interface *ifaces, void (*foo)(struct Interface *iface, void *), void *data);
 void free_ifaces(struct Interface *ifaces);

--- a/send.c
+++ b/send.c
@@ -328,7 +328,7 @@ static struct safe_buffer_list *add_ra_options_prefix(struct safe_buffer_list *s
 						      struct in6_addr const *dest)
 {
 	while (prefix) {
-		if ((!prefix->DecrementLifetimesFlag || prefix->curr_preferredlft > 0)) {
+		if ((!prefix->DecrementLifetimesFlag || prefix->curr_preferredlft > 0) && prefix->AdvSendPrefix) {
 			struct in6_addr zero = {};
 			if (prefix->if6to4[0] || prefix->if6[0] || 0 == memcmp(&prefix->Prefix, &zero, sizeof(zero))) {
 				if (prefix->if6to4[0]) {

--- a/test/client.c
+++ b/test/client.c
@@ -9,7 +9,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#include <cJSON.h>
+#include <cjson/cJSON.h>
 
 #define SERVER_PATH "/tmp/radvd.sock"
 #define MAXLINE 2048
@@ -30,62 +30,39 @@ int main(int argc, char *argv[])
 	remote.sun_family = AF_UNIX;
 	strcpy(remote.sun_path, SERVER_PATH);
 
-	printf("Sending data...\n");
+	FILE *f = NULL;
+	long len = 0;
+	char *data = NULL;
 
-	cJSON *ra_config = cJSON_CreateObject();
-	cJSON *interface = cJSON_CreateObject();
-	cJSON *prefix1 = cJSON_CreateObject();
-	cJSON *prefix2 = cJSON_CreateObject();
-	cJSON *prefix3 = cJSON_CreateObject();
-	cJSON *prefixes = cJSON_CreateArray();
+	/* open in read binary mode */
+	f = fopen("message_example.json", "rb");
+	/* get the length */
+	fseek(f, 0, SEEK_END);
+	len = ftell(f);
+	fseek(f, 0, SEEK_SET);
 
-	cJSON_bool adv_autonomous = 1;
-	cJSON_bool adv_on_link = 1;
-	cJSON_bool action1 = atoi(argv[5]);
-	cJSON_bool action2 = atoi(argv[6]);
-	cJSON_bool action3 = atoi(argv[7]);
-	cJSON_bool action4 = atoi(argv[8]);
-	double max_rtr_interval = 650.5;
-	double min_rtr_interval = 350.5;
-	double adv_default_lifetime = 2 * max_rtr_interval;
-	cJSON_AddItemToObject(ra_config, "interface", interface);
-	cJSON_AddBoolToObject(interface, "destructive", action1);
-	cJSON_AddStringToObject(interface, "name", argv[1]);
-	cJSON_AddStringToObject(interface, "cdb_name", argv[2]);
-	cJSON_AddBoolToObject(interface, "adv_send_advert", atoi(argv[3]));
-	cJSON_AddNumberToObject(interface, "max_rtr_interval", max_rtr_interval);
-	cJSON_AddNumberToObject(interface, "min_rtr_interval", min_rtr_interval);
-	cJSON_AddNumberToObject(interface, "adv_default_lifetime", adv_default_lifetime);
-	cJSON_AddItemToObject(interface, "prefixes", prefixes);
-	cJSON_AddBoolToObject(prefix1, "destructive", action2);
-	cJSON_AddStringToObject(prefix1, "addr", argv[4]);
-	if(!action2) {
-		cJSON_AddNumberToObject(prefix1, "adv_autonomous", adv_autonomous);
-		cJSON_AddNumberToObject(prefix1, "adv_on_link", adv_on_link);
+	data = (char *)malloc(len + 1);
+
+	fread(data, 1, len, f);
+	data[len] = '\0';
+	fclose(f);
+
+	char *out = NULL;
+	cJSON *json = NULL;
+
+	json = cJSON_Parse(data);
+
+	if (!json) {
+		printf("Error before: [%s]\n", cJSON_GetErrorPtr());
+		exit(1);
 	}
-	cJSON_AddItemToArray(prefixes, prefix1);
 
-	cJSON_AddBoolToObject(prefix2, "destructive", action3);
-	cJSON_AddStringToObject(prefix2, "addr", "2020::1");
-	if(!action3) {
-		cJSON_AddNumberToObject(prefix2, "adv_autonomous", adv_autonomous);
-		cJSON_AddNumberToObject(prefix2, "adv_on_link", adv_on_link);
-	}
-	cJSON_AddItemToArray(prefixes, prefix2);
+	out = cJSON_Print(json);
+	cJSON_Delete(json);
+	printf("%s\n", out);
 
-	cJSON_AddBoolToObject(prefix3, "destructive", action4);
-	cJSON_AddStringToObject(prefix3, "addr", "abcd::1");
-	if(!action4) {
-		cJSON_AddNumberToObject(prefix3, "adv_autonomous", adv_autonomous);
-		cJSON_AddNumberToObject(prefix3, "adv_on_link", adv_on_link);
-	}
-	cJSON_AddItemToArray(prefixes, prefix3);
-
-	char *out = cJSON_Print(ra_config);
-	printf("%s\n%lu\n", out, strlen(out));
 	printf("%lu\n", sendto(client_socket, out, strlen(out), 0, (struct sockaddr *)&remote, sizeof(remote)));
 
-	cJSON_Delete(ra_config);
 	free(out);
 	close(client_socket);
 	return 0;

--- a/test/message_example.json
+++ b/test/message_example.json
@@ -1,0 +1,32 @@
+{
+    "interface":    {
+            "destructive":  false,
+            "name": "wlp1",
+            "cdb_name":     "cdb_wlp1",
+            "adv_send_advert":      true,
+            "max_rtr_interval":     650.5,
+            "min_rtr_interval":     350.5,
+            "adv_default_lifetime": 1301,
+            "prefixes":     [{
+                            "destructive":  false,
+                            "addr": "cafe::1",
+                            "adv_autonomous":       true,
+                            "adv_on_link":  true,
+                            "adv_send_prefix":      true
+
+                    }, {
+                            "destructive":  false,
+                            "addr": "2020::1",
+                            "adv_autonomous":       true,
+                            "adv_on_link":  true,
+                            "adv_send_prefix":      true
+
+                    }, {
+                            "destructive":  false,
+                            "addr": "abcd::1",
+                            "adv_autonomous":       true,
+                            "adv_on_link":  true,
+                            "adv_send_prefix":      false
+                    }]
+    }
+}


### PR DESCRIPTION
Add new feature AdvSendPrefix flag to allow enable/disable per prefix

- Also move #define SERVER_PATH to out of the #ifdef HAVE_GETOPT_LONG
- Add json example message file
- Change test client: now client parses message from message_example.json

Signed-off-by: LDS-Labs <lds@lds.ifce.edu.br>