### PR TITLE
Add reload flag and modify 'destructive' flag to 'action'

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -465,7 +465,7 @@ struct Interface *create_iface(const char *iface_name)
 
 	if (iface == NULL) {
 		flog(LOG_CRIT, "malloc failed: %s", strerror(errno));
-		return NULL;
+		exit(EXIT_FAILURE);
 	}
 
 	iface_init_defaults(iface);
@@ -481,7 +481,7 @@ struct AdvPrefix *create_prefix(const struct in6_addr addr6)
 
 	if (prefix == NULL) {
 		flog(LOG_CRIT, "malloc failed: %s", strerror(errno));
-		return NULL;
+		exit(EXIT_FAILURE);
 	}
 
 	prefix_init_defaults(prefix);
@@ -524,37 +524,42 @@ struct Interface *update_iface(struct Interface *iface, cJSON *cjson_iface)
 {
 	cJSON *cjson_ptr;
 
+	if (iface == NULL) {
+		dlog(LOG_DEBUG, 4, "Cannot update null iface");
+		return NULL;
+	}
+
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_iface, "name"))) {
 		const char *iface_name = cJSON_GetStringValue(cjson_ptr);
 		strncpy(iface->props.name, iface_name, IFNAMSIZ);
 		iface->props.name[IFNAMSIZ - 1] = '\0';
-		dlog(LOG_DEBUG, 1, "cJSON name %s", iface->props.name);
+		dlog(LOG_DEBUG, 4, "cJSON name %s", iface->props.name);
 	}
 
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_iface, "max_rtr_interval"))) {
 		if (cJSON_IsNumber(cjson_ptr)) {
 			iface->MaxRtrAdvInterval = cjson_ptr->valuedouble;
-			dlog(LOG_DEBUG, 1, "cJSON max_rtr_interval %lf", iface->MaxRtrAdvInterval);
+			dlog(LOG_DEBUG, 4, "cJSON max_rtr_interval %lf", iface->MaxRtrAdvInterval);
 		}
 	}
 
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_iface, "min_rtr_interval"))) {
 		if (cJSON_IsNumber(cjson_ptr)) {
 			iface->MinRtrAdvInterval = cjson_ptr->valuedouble;
-			dlog(LOG_DEBUG, 1, "cJSON min_rtr_interval %lf", iface->MinRtrAdvInterval);
+			dlog(LOG_DEBUG, 4, "cJSON min_rtr_interval %lf", iface->MinRtrAdvInterval);
 		}
 	}
 
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_iface, "adv_default_lifetime"))) {
 		if (cJSON_IsNumber(cjson_ptr)) {
 			iface->ra_header_info.AdvDefaultLifetime = cjson_ptr->valueint;
-			dlog(LOG_DEBUG, 1, "cJSON adv_default_lifetime %d", iface->ra_header_info.AdvDefaultLifetime);
+			dlog(LOG_DEBUG, 4, "cJSON adv_default_lifetime %d", iface->ra_header_info.AdvDefaultLifetime);
 		}
 	}
 
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_iface, "adv_send_advert"))) {
 		iface->AdvSendAdvert = cJSON_IsTrue(cjson_ptr);
-		dlog(LOG_DEBUG, 1, "cJSON adv_send_advert %d", iface->AdvSendAdvert);
+		dlog(LOG_DEBUG, 4, "cJSON adv_send_advert %d", iface->AdvSendAdvert);
 	}
 
 	return iface;
@@ -566,17 +571,17 @@ struct AdvPrefix *update_iface_prefix(struct AdvPrefix *prefix, cJSON *cjson_pre
 
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_prefix, "adv_autonomous"))) {
 		prefix->AdvAutonomousFlag = cJSON_IsTrue(cjson_ptr);
-		dlog(LOG_DEBUG, 1, "cJSON adv_autonomous %d", prefix->AdvAutonomousFlag);
+		dlog(LOG_DEBUG, 4, "cJSON adv_autonomous %d", prefix->AdvAutonomousFlag);
 	}
 
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_prefix, "adv_on_link"))) {
 		prefix->AdvOnLinkFlag = cJSON_IsTrue(cjson_ptr);
-		dlog(LOG_DEBUG, 1, "cJSON adv_on_link %d", prefix->AdvOnLinkFlag);
+		dlog(LOG_DEBUG, 4, "cJSON adv_on_link %d", prefix->AdvOnLinkFlag);
 	}
 
 	if ((cjson_ptr = cJSON_GetObjectItemCaseSensitive(cjson_prefix, "adv_send_prefix"))) {
 		prefix->AdvSendPrefix = cJSON_IsTrue(cjson_ptr);
-		dlog(LOG_DEBUG, 1, "cJSON adv_send_prefix %d", prefix->AdvSendPrefix);
+		dlog(LOG_DEBUG, 4, "cJSON adv_send_prefix %d", prefix->AdvSendPrefix);
 	}
 
 	return prefix;
@@ -594,7 +599,7 @@ struct Interface *delete_iface_by_cdb_name(struct Interface *ifaces, const char 
 			} else {
 				ifaces = current->next;
 			}
-			dlog(LOG_DEBUG, 1, "iface found, deleting");
+			dlog(LOG_DEBUG, 5, "iface found, deleting");
 			free(current);
 			return ifaces;
 		}
@@ -602,7 +607,7 @@ struct Interface *delete_iface_by_cdb_name(struct Interface *ifaces, const char 
 		current = current->next;
 	}
 
-	dlog(LOG_DEBUG, 1, "iface not found");
+	dlog(LOG_DEBUG, 5, "no iface to delete");
 	return ifaces;
 }
 
@@ -618,7 +623,7 @@ struct AdvPrefix *delete_iface_prefix_by_addr(struct AdvPrefix *prefix_list, con
 				flog(LOG_WARNING, "Prefix reference counter is negative");
 			}
 
-			dlog(LOG_DEBUG, 1, "Decreasing prefix reference counter: %d", current->ref);
+			dlog(LOG_DEBUG, 5, "Decreasing prefix reference counter: %d", current->ref);
 
 			if (current->ref == 0) {
 				if (previous) {
@@ -630,7 +635,7 @@ struct AdvPrefix *delete_iface_prefix_by_addr(struct AdvPrefix *prefix_list, con
 				char addr_str[INET6_ADDRSTRLEN];
 				addrtostr(&addr6, addr_str, sizeof(addr_str));
 				
-				dlog(LOG_DEBUG, 1, "Deleting prefix %s", addr_str);
+				dlog(LOG_DEBUG, 5, "Deleting prefix %s", addr_str);
 				free(current);
 			}
 			return prefix_list;
@@ -638,6 +643,6 @@ struct AdvPrefix *delete_iface_prefix_by_addr(struct AdvPrefix *prefix_list, con
 		previous = current;
 		current = current->next;
 	}
-	dlog(LOG_DEBUG, 1, "prefix not found");
+	dlog(LOG_DEBUG, 4, "prefix not found");
 	return prefix_list;
 }

--- a/test/client.c
+++ b/test/client.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	char *data = NULL;
 
 	/* open in read binary mode */
-	f = fopen("message_example.json", "rb");
+	f = fopen(argv[1], "rb");
 	/* get the length */
 	fseek(f, 0, SEEK_END);
 	len = ftell(f);

--- a/test/message_example.json
+++ b/test/message_example.json
@@ -1,6 +1,6 @@
 {
         "interface": {
-                "destructive": false,
+                "action": "CREATE",
                 "name": "wlp1",
                 "cdb_name": "cdb_wlp1",
                 "adv_send_advert": true,

--- a/test/reload_message_example.json
+++ b/test/reload_message_example.json
@@ -1,0 +1,6 @@
+{
+    "interface": {
+            "cdb_name": "cdb_iface1",
+            "reload": true
+    }
+}

--- a/test/send.c
+++ b/test/send.c
@@ -416,6 +416,7 @@ START_TEST(test_json_configure_one_iface_with_one_prefix)
 	ck_assert_str_eq("iface1", iface->props.name);
 	ck_assert_str_eq("cdb_iface1", iface->props.cdb_name);
 	struct AdvPrefix *prefix = iface->AdvPrefixList;
+	ck_assert_ptr_ne(0, prefix);
 	char addr_str[INET6_ADDRSTRLEN];
 	addrtostr(&prefix->Prefix, addr_str, sizeof(addr_str));
 	ck_assert_str_eq("cafe:2020:6969:abcd::", addr_str);
@@ -439,6 +440,7 @@ START_TEST(test_json_delete_configured_prefix)
 	ck_assert_str_eq("iface1", iface->props.name);
 	ck_assert_str_eq("cdb_iface1", iface->props.cdb_name);
 	struct AdvPrefix *prefix = iface->AdvPrefixList;
+	ck_assert_ptr_ne(0, prefix);
 	char addr_str[INET6_ADDRSTRLEN];
 	addrtostr(&prefix->Prefix, addr_str, sizeof(addr_str));
 	ck_assert_str_eq("cafe:2020:6969:abcd::", addr_str);
@@ -468,6 +470,7 @@ START_TEST(test_json_check_reference_counter)
 	
 	iface = process_command(msg, iface);
 	struct AdvPrefix *prefix = iface->AdvPrefixList;
+	ck_assert_ptr_ne(0, prefix);
 	char addr_str[INET6_ADDRSTRLEN];
 	addrtostr(&prefix->Prefix, addr_str, sizeof(addr_str));
 	ck_assert_str_eq("cafe:2020:6969:abcd::", addr_str);

--- a/test/test_msg_configured_iface.json
+++ b/test/test_msg_configured_iface.json
@@ -1,6 +1,6 @@
 {
         "interface": {
-                "destructive": false,
+                "action": "CREATE",
                 "name": "iface1",
                 "cdb_name": "cdb_iface1",
                 "adv_send_advert": false,

--- a/test/test_msg_default_iface_with_one_prefix.json
+++ b/test/test_msg_default_iface_with_one_prefix.json
@@ -1,6 +1,6 @@
 {
         "interface": {
-                "destructive": false,
+                "action": "CREATE",
                 "name": "iface1",
                 "cdb_name": "cdb_iface1",
                 "prefixes": [

--- a/test/test_msg_delete_prefix.json
+++ b/test/test_msg_delete_prefix.json
@@ -1,6 +1,5 @@
 {
         "interface": {
-                "destructive": false,
                 "name": "iface1",
                 "cdb_name": "cdb_iface1",
                 "prefixes": [

--- a/test/test_msg_destroy_iface.json
+++ b/test/test_msg_destroy_iface.json
@@ -1,6 +1,6 @@
 {
         "interface": {
-                "destructive": true,
+            "action": "DESTROY",
                 "cdb_name": "cdb_iface1"
         }
 }

--- a/test/test_msg_iface_with_default_config.json
+++ b/test/test_msg_iface_with_default_config.json
@@ -1,6 +1,6 @@
 {
         "interface": {
-                "destructive": false,
+                "action": "CREATE",
                 "name": "iface1",
                 "cdb_name": "cdb_iface1"
         }


### PR DESCRIPTION
Because the log debug level 1 became very verbose,
some debug levels of messages have been changed. 
Now the action flag manages creation and deletion
of interfaces.
